### PR TITLE
fixes contributing link

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ If you run into problems, [please raise a GitHub issue,](https://github.com/muxi
 
 ## Contributing
 
-Please do not submit PRs against this package. It is generated from our OpenAPI definitions - [Please open an issue instead!](https://github.com/muxinc/mux-python/issues)
+Please do not submit PRs against this package. It is generated from our OpenAPI definitions - [Please open an issue instead!](https://github.com/muxinc/mux-go/issues)
 
 ## License
 


### PR DESCRIPTION
Fixes the "contributing" link to correctly point to `mux-go`