### PR TITLE
Improve error handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ func main() {
 
 ## Exceptions & Error Handling
 
-All API calls return an err as their final return value. Below is documented the errors you might want to check for.
+All API calls return an err as their final return value. Below is documented the errors you might want to check for. You can check `error.Body` on all errors to see the full HTTP response.
 
 ### BadRequestError
 
-`BadRequestError` is returned when a you make a bad request to Mux, this likely means you've passed in an invalid parameter to the API call. Check `error.Body` to see the full HTTP response.
+`BadRequestError` is returned when a you make a bad request to Mux, this likely means you've passed in an invalid parameter to the API call. 
 
 ### UnauthorizedError
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,38 @@ func main() {
 }
 ```
 
+## Exceptions & Error Handling
+
+All API calls return an err as their final return value. Below is documented the errors you might want to check for.
+
+### BadRequestError
+
+`BadRequestError` is returned when a you make a bad request to Mux, this likely means you've passed in an invalid parameter to the API call. Check `error.Body` to see the full HTTP response.
+
+### UnauthorizedError
+
+`UnauthorizedError` is returned when Mux cannot authenticate your request. [You should check you have configured your credentials correctly.](#authentication)
+
+### ForbiddenError
+
+`ForbiddenError` is returned you don't have permission to access that resource. [You should check you have configured your credentials correctly.](#authentication)
+
+### NotFoundError
+
+`NotFoundError` is returned when a resource is not found. This is useful when trying to get an entity by its ID.
+
+### TooManyRequestsError
+
+`TooManyRequestsError` is returned when you exceed the manimum request that Mux allows. Please get in touch with [support@mux.com](mailto:support@mux.com) if you need to talk about this limit.
+
+### ServiceError
+
+`ServiceError` is returned when Mux returns a HTTP 5XX Status Code. If you encounter this reproducibly, please get in touch with [support@mux.com](mailto:support@mux.com).
+
+### GenericOpenAPIError
+
+`GenericOpenAPIError` is a fallback Error which may be returned in some edge cases. This will be deprecated in a later release but remains present for API compatibility.
+
 ## Documentation
 
 [Be sure to check out the documentation in the `docs` directory.](docs/)

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ func main() {
 }
 ```
 
-## Exceptions & Error Handling
+## Errors & Error Handling
 
 All API calls return an err as their final return value. Below is documented the errors you might want to check for. You can check `error.Body` on all errors to see the full HTTP response.
 

--- a/api_assets.go
+++ b/api_assets.go
@@ -70,22 +70,10 @@ func (a *AssetsApiService) CreateAsset(createAssetRequest CreateAssetRequest, op
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v AssetResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -159,22 +147,10 @@ func (a *AssetsApiService) CreateAssetPlaybackId(aSSETID string, createPlaybackI
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v CreatePlaybackIdResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -245,12 +221,10 @@ func (a *AssetsApiService) DeleteAsset(aSSETID string, opts ...APIOption) error 
 		return err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		return newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -313,12 +287,10 @@ func (a *AssetsApiService) DeleteAssetPlaybackId(aSSETID string, pLAYBACKID stri
 		return err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		return newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -381,22 +353,10 @@ func (a *AssetsApiService) GetAsset(aSSETID string, opts ...APIOption) (AssetRes
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v AssetResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -468,22 +428,10 @@ func (a *AssetsApiService) GetAssetInputInfo(aSSETID string, opts ...APIOption) 
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v GetAssetInputInfoResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -556,22 +504,10 @@ func (a *AssetsApiService) GetAssetPlaybackId(aSSETID string, pLAYBACKID string,
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v GetAssetPlaybackIdResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -659,22 +595,10 @@ func (a *AssetsApiService) ListAssets(opts ...APIOption) (ListAssetsResponse, er
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListAssetsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -748,22 +672,10 @@ func (a *AssetsApiService) UpdateAssetMp4Support(aSSETID string, updateAssetMp4S
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v AssetResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_direct_uploads.go
+++ b/api_direct_uploads.go
@@ -69,22 +69,10 @@ func (a *DirectUploadsApiService) CancelDirectUpload(uPLOADID string, opts ...AP
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v UploadResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -157,22 +145,10 @@ func (a *DirectUploadsApiService) CreateDirectUpload(createUploadRequest CreateU
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v UploadResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -244,22 +220,10 @@ func (a *DirectUploadsApiService) GetDirectUpload(uPLOADID string, opts ...APIOp
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v UploadResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -347,22 +311,10 @@ func (a *DirectUploadsApiService) ListDirectUploads(opts ...APIOption) (ListUplo
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListUploadsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_errors.go
+++ b/api_errors.go
@@ -92,22 +92,10 @@ func (a *ErrorsApiService) ListErrors(opts ...APIOption) (ListErrorsResponse, er
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListErrorsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_exports.go
+++ b/api_exports.go
@@ -67,22 +67,10 @@ func (a *ExportsApiService) ListExports(opts ...APIOption) (ListExportsResponse,
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListExportsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_filters.go
+++ b/api_filters.go
@@ -102,22 +102,10 @@ func (a *FiltersApiService) ListFilterValues(fILTERID string, opts ...APIOption)
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListFilterValuesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -188,22 +176,10 @@ func (a *FiltersApiService) ListFilters(opts ...APIOption) (ListFiltersResponse,
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListFiltersResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_live_streams.go
+++ b/api_live_streams.go
@@ -70,22 +70,10 @@ func (a *LiveStreamsApiService) CreateLiveStream(createLiveStreamRequest CreateL
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v LiveStreamResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -159,22 +147,10 @@ func (a *LiveStreamsApiService) CreateLiveStreamPlaybackId(lIVESTREAMID string, 
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v CreatePlaybackIdResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -245,12 +221,10 @@ func (a *LiveStreamsApiService) DeleteLiveStream(lIVESTREAMID string, opts ...AP
 		return err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		return newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -313,12 +287,10 @@ func (a *LiveStreamsApiService) DeleteLiveStreamPlaybackId(lIVESTREAMID string, 
 		return err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		return newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -381,22 +353,10 @@ func (a *LiveStreamsApiService) GetLiveStream(lIVESTREAMID string, opts ...APIOp
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v LiveStreamResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -484,22 +444,10 @@ func (a *LiveStreamsApiService) ListLiveStreams(opts ...APIOption) (ListLiveStre
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListLiveStreamsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -571,22 +519,10 @@ func (a *LiveStreamsApiService) ResetStreamKey(lIVESTREAMID string, opts ...APIO
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v LiveStreamResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -658,22 +594,10 @@ func (a *LiveStreamsApiService) SignalLiveStreamComplete(lIVESTREAMID string, op
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v SignalLiveStreamCompleteResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_metrics.go
+++ b/api_metrics.go
@@ -106,22 +106,10 @@ func (a *MetricsApiService) GetMetricTimeseriesData(mETRICID string, opts ...API
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v GetMetricTimeseriesDataResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -222,22 +210,10 @@ func (a *MetricsApiService) GetOverallValues(mETRICID string, opts ...APIOption)
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v GetOverallValuesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -341,22 +317,10 @@ func (a *MetricsApiService) ListAllMetricValues(opts ...APIOption) (ListAllMetri
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListAllMetricValuesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -477,22 +441,10 @@ func (a *MetricsApiService) ListBreakdownValues(mETRICID string, opts ...APIOpti
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListBreakdownValuesResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -589,22 +541,10 @@ func (a *MetricsApiService) ListInsights(mETRICID string, opts ...APIOption) (Li
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListInsightsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_url_signing_keys.go
+++ b/api_url_signing_keys.go
@@ -68,22 +68,10 @@ func (a *URLSigningKeysApiService) CreateUrlSigningKey(opts ...APIOption) (Signi
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 201 {
-			var v SigningKeyResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -154,12 +142,10 @@ func (a *URLSigningKeysApiService) DeleteUrlSigningKey(sIGNINGKEYID string, opts
 		return err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		return newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -222,22 +208,10 @@ func (a *URLSigningKeysApiService) GetUrlSigningKey(sIGNINGKEYID string, opts ..
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v SigningKeyResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -325,22 +299,10 @@ func (a *URLSigningKeysApiService) ListUrlSigningKeys(opts ...APIOption) (ListSi
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListSigningKeysResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/api_video_views.go
+++ b/api_video_views.go
@@ -69,22 +69,10 @@ func (a *VideoViewsApiService) GetVideoView(vIDEOVIEWID string, opts ...APIOptio
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v VideoViewResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
@@ -200,22 +188,10 @@ func (a *VideoViewsApiService) ListVideoViews(opts ...APIOption) (ListVideoViews
 		return localVarReturnValue, err
 	}
 
-	if localVarHttpResponse.StatusCode >= 300 {
-		newErr := GenericOpenAPIError{
-			body:  localVarBody,
-			error: localVarHttpResponse.Status,
-		}
-		if localVarHttpResponse.StatusCode == 200 {
-			var v ListVideoViewsResponse
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = err.Error()
-				return localVarReturnValue, newErr
-			}
-			newErr.model = v
-			return localVarReturnValue, newErr
-		}
-		return localVarReturnValue, newErr
+	// Check for common HTTP error status codes
+	err = CheckForHttpError(localVarHttpResponse.StatusCode, localVarBody)
+	if err != nil {
+		return localVarReturnValue, err
 	}
 
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))

--- a/client.go
+++ b/client.go
@@ -433,3 +433,88 @@ func (e GenericOpenAPIError) Body() []byte {
 func (e GenericOpenAPIError) Model() interface{} {
 	return e.model
 }
+
+// Below are the custom Mux API Error types, so that users of the SDK can identify
+// what issue they're running into more easily.
+
+// Generic 400 error
+type BadRequestError struct {
+	error string
+}
+
+func (e BadRequestError) Error() string {
+	return e.error
+}
+
+// 401 Error
+type UnauthorizedError struct {
+	error string
+}
+
+func (e UnauthorizedError) Error() string {
+	return e.error
+}
+
+// 403 Error
+type ForbiddenError struct {
+	error string
+}
+
+func (e ForbiddenError) Error() string {
+	return e.error
+}
+
+// 404 Error
+type NotFoundError struct {
+	error string
+}
+
+func (e NotFoundError) Error() string {
+	return e.error
+}
+
+// 429 Error
+type TooManyRequestsError struct {
+	error string
+}
+
+func (e TooManyRequestsError) Error() string {
+	return e.error
+}
+
+// 5XX Error
+type ServiceError struct {
+	error string
+}
+
+func (e ServiceError) Error() string {
+	return e.error
+}
+
+// Helper to check for common non-200 errors
+func CheckForHttpError(code int, body []byte) error {
+
+	if code >= 200 && code <= 299 {
+		return nil
+	}
+
+	switch code {
+	case 400:
+		return BadRequestError{"Bad Request"}
+	case 401:
+		return UnauthorizedError{"Unauthorized"}
+	case 403:
+		return ForbiddenError{"Forbidden"}
+	case 404:
+		return NotFoundError{"Not Found"}
+	case 429:
+		return TooManyRequestsError{"Slow Down"}
+	}
+
+	if code >= 500 && code <= 599 {
+		return ServiceError{"Service Error"}
+	}
+
+	// return GenericOpenAPIError{"Generic Error"};
+	return nil
+}

--- a/client.go
+++ b/client.go
@@ -439,6 +439,7 @@ func (e GenericOpenAPIError) Model() interface{} {
 
 // Generic 400 error
 type BadRequestError struct {
+	body  []byte
 	error string
 }
 
@@ -448,6 +449,7 @@ func (e BadRequestError) Error() string {
 
 // 401 Error
 type UnauthorizedError struct {
+	body  []byte
 	error string
 }
 
@@ -455,8 +457,13 @@ func (e UnauthorizedError) Error() string {
 	return e.error
 }
 
+func (e UnauthorizedError) Body() []byte {
+	return e.body
+}
+
 // 403 Error
 type ForbiddenError struct {
+	body  []byte
 	error string
 }
 
@@ -464,8 +471,13 @@ func (e ForbiddenError) Error() string {
 	return e.error
 }
 
+func (e ForbiddenError) Body() []byte {
+	return e.body
+}
+
 // 404 Error
 type NotFoundError struct {
+	body  []byte
 	error string
 }
 
@@ -473,8 +485,13 @@ func (e NotFoundError) Error() string {
 	return e.error
 }
 
+func (e NotFoundError) Body() []byte {
+	return e.body
+}
+
 // 429 Error
 type TooManyRequestsError struct {
+	body  []byte
 	error string
 }
 
@@ -482,13 +499,27 @@ func (e TooManyRequestsError) Error() string {
 	return e.error
 }
 
+func (e TooManyRequestsError) Body() []byte {
+	return e.body
+}
+
 // 5XX Error
 type ServiceError struct {
-	error string
+	body   []byte
+	status int
+	error  string
 }
 
 func (e ServiceError) Error() string {
 	return e.error
+}
+
+func (e ServiceError) Body() []byte {
+	return e.body
+}
+
+func (e ServiceError) Code() int {
+	return e.status
 }
 
 // Helper to check for common non-200 errors
@@ -500,19 +531,19 @@ func CheckForHttpError(code int, body []byte) error {
 
 	switch code {
 	case 400:
-		return BadRequestError{"Bad Request"}
+		return BadRequestError{body: body, error: "Bad Request"}
 	case 401:
-		return UnauthorizedError{"Unauthorized"}
+		return UnauthorizedError{body: body, error: "Unauthorized"}
 	case 403:
-		return ForbiddenError{"Forbidden"}
+		return ForbiddenError{body: body, error: "Forbidden"}
 	case 404:
-		return NotFoundError{"Not Found"}
+		return NotFoundError{body: body, error: "Not Found"}
 	case 429:
-		return TooManyRequestsError{"Slow Down"}
+		return TooManyRequestsError{body: body, error: "Too Many Requests"}
 	}
 
 	if code >= 500 && code <= 599 {
-		return ServiceError{"Service Error"}
+		return ServiceError{body: body, status: code, error: "Service Error"}
 	}
 
 	return GenericOpenAPIError{body: body, error: "Generic Error"}

--- a/client.go
+++ b/client.go
@@ -515,6 +515,5 @@ func CheckForHttpError(code int, body []byte) error {
 		return ServiceError{"Service Error"}
 	}
 
-	// return GenericOpenAPIError{"Generic Error"};
-	return nil
+	return GenericOpenAPIError{body: body, error: "Generic Error"}
 }

--- a/configuration.go
+++ b/configuration.go
@@ -22,7 +22,7 @@ type ConfigurationOption func(*Configuration)
 func NewConfiguration(opts ...ConfigurationOption) *Configuration {
 	cfg := &Configuration{
 		basePath:  "https://api.mux.com",
-		userAgent: "Mux Go | 0.2.2",
+		userAgent: "Mux Go | 0.2.3",
 	}
 	for _, opt := range opts {
 		opt(cfg)

--- a/configuration.go
+++ b/configuration.go
@@ -22,7 +22,7 @@ type ConfigurationOption func(*Configuration)
 func NewConfiguration(opts ...ConfigurationOption) *Configuration {
 	cfg := &Configuration{
 		basePath:  "https://api.mux.com",
-		userAgent: "Mux Go | 0.2.3",
+		userAgent: "Mux Go | 0.3.0",
 	}
 	for _, opt := range opts {
 		opt(cfg)


### PR DESCRIPTION
Our handling of errors wasn't great, and among other things generated a bunch of dead code.

I've replaced the error handling entirely with a common function that captures common use cases, and matches and expands on what we have in the python and ruby SDKs.

Docs: https://github.com/muxinc/mux-go/tree/improve-error-handling#errors--error-handling

I've left `GenericOpenAPIError` in place for now, but we'll remove/rename it in the next major version bump. 