### PR TITLE
Add GoDoc shield to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Mux Go Banner](https://banner.mux.dev/?image=go)
 
 ![](https://github.com/muxinc/mux-go/workflows/Integration%20Test/badge.svg)
+[![GoDoc](https://godoc.org/github.com/muxinc/mux-go?status.svg)](https://godoc.org/github.com/muxinc/mux-go)
 
 # Mux Go
 


### PR DESCRIPTION
Makes it easier for users to start perusing the GoDoc for this SDK (which is generally where I like to go first when checking something out).