### PR TITLE
Update README to support GoDoc shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Mux Go Banner](https://banner.mux.dev/?image=go)
 
 ![](https://github.com/muxinc/mux-go/workflows/Integration%20Test/badge.svg)
+[![GoDoc](https://godoc.org/github.com/muxinc/mux-go?status.svg)](https://godoc.org/github.com/muxinc/mux-go)
 
 # Mux Go
 


### PR DESCRIPTION
Updates README based on generation from SDK. GoDoc shields are a handy way to get quick access to GoDoc (which is often where I go first when I want to learn about a library/SDK).