### PR TITLE
Update README to include version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Not familiar with Mux? Check out https://mux.com/ for more information.
 ## Installation
 
 ```
-go get github.com/muxinc/mux-go
+go get github.com/muxinc/mux-go@0.15.1
 ```
 
 ## Getting Started


### PR DESCRIPTION
See https://github.com/muxinc/mux-go/issues/33#issuecomment-918808480 for an example of what happens if you just run `go get` without a version. I believe this stems from a v1 being released and then removed, so the install instructions now need the version to be explicit.