### PR TITLE
Bump version in go.mod to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/muxinc/mux-go/v4
+module github.com/muxinc/mux-go/v5
 
 go 1.15
 


### PR DESCRIPTION
I uncovered some other versioning problems while testing this change, but pushing this in the short term to unblock usage of this version.